### PR TITLE
React 19 Compatibility: Remove Deprecated defaultProps

### DIFF
--- a/lib/component/from-object.js
+++ b/lib/component/from-object.js
@@ -12,7 +12,7 @@ var mapChildren     = R.pipe(
     R.map(objectToElement)
 );
 
-function fromObject (obj, isRoot) {
+function fromObject (obj, isRoot, propsExpression) {
     if (typeof obj === 'string') {
         return JSON.stringify(obj);
     }
@@ -32,7 +32,7 @@ function fromObject (obj, isRoot) {
         result += ',' + JSON.stringify(props);
     }
     else if (isRoot) {
-        result += ',props';
+        result += ',' + (propsExpression || 'props');
     }
     else {
         result += ',null';

--- a/lib/component/stringify.js
+++ b/lib/component/stringify.js
@@ -3,17 +3,31 @@ var fromObject = require('./from-object');
 
 module.exports = R.curry(function stringify (opts, tree) {
     var displayName = opts.displayName;
+    var defaultProps = tree.props || {};
+    var defaultPropsEntries = Object.keys(defaultProps);
+    
+    // Create destructuring assignment for default props
+    var destructuringPattern = defaultPropsEntries.length > 0 
+        ? '{' + defaultPropsEntries.map(function(key) {
+            return key + ' = ' + JSON.stringify(defaultProps[key]);
+          }).join(', ') + ', ...restProps}'
+        : 'props';
+    
+    // Merge defaults with rest props for the final props object
+    var propsExpression = defaultPropsEntries.length > 0
+        ? 'Object.assign({' + defaultPropsEntries.map(function(key) {
+            return key + ': ' + key;
+          }).join(', ') + '}, restProps)'
+        : 'props';
 
     var preamble = [
         'var React = require(\'react\');',
         '',
-        'function ' + displayName + ' (props) {',
+        'function ' + displayName + ' (' + destructuringPattern + ') {',
     ];
 
     var postamble = [
         '}',
-        '',
-        displayName + '.defaultProps = ' + JSON.stringify(tree.props || {}) + ';',
         '',
         'module.exports = ' + displayName + ';',
         '',
@@ -22,7 +36,7 @@ module.exports = R.curry(function stringify (opts, tree) {
     ];
 
     return preamble.
-        concat([fromObject(tree, true)]).
+        concat([fromObject(tree, true, propsExpression)]).
         concat(postamble).
         join('\n');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3177,16 +3177,16 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3194,17 +3194,16 @@
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.4",
-      "integrity": "sha512-QbMPI8teYlZBIBqDgmIWfDKO149dGtQV2ium8WniCaARFFRd1e+IES1LA4sSGcVTFdVL628+163WUbxev7R/aQ==",
-      "deprecated": "This package is no longer supported.",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
@@ -3213,16 +3212,16 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "integrity": "sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3231,16 +3230,16 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.0.1",
-      "integrity": "sha512-cKnqUJAC8G6cuN1DiRRTifu+s1BlAQNtalzGphFEV0pl0p46dsxJD4l1AOlyKJeLZOFzo3c34R7F3djxaCu8Kw==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3248,30 +3247,30 @@
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "2.6.9",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -3279,9 +3278,9 @@
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.5.1",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "iojs": ">=1.0.0",
@@ -3290,16 +3289,16 @@
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true,
       "inBundle": true,
+      "license": "Apache-2.0",
       "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
@@ -3310,9 +3309,9 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.5",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "minipass": "^2.2.1"
@@ -3320,17 +3319,16 @@
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
-      "deprecated": "This package is no longer supported.",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
@@ -3345,10 +3343,9 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.2",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -3364,16 +3361,16 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.21",
-      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "safer-buffer": "^2.1.0"
@@ -3384,9 +3381,9 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.1",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
@@ -3394,10 +3391,9 @@
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -3406,17 +3402,16 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.3",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "deprecated": "Please update to ini >=1.3.6 to avoid a prototype pollution issue",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "engines": {
         "node": "*"
@@ -3424,9 +3419,9 @@
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
@@ -3437,16 +3432,16 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3457,16 +3452,16 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.2.4",
-      "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.1",
@@ -3475,9 +3470,9 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.1.0",
-      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "minipass": "^2.2.1"
@@ -3485,10 +3480,9 @@
     },
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "minimist": "0.0.8"
@@ -3499,16 +3493,16 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.0.0",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.2.0",
-      "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "debug": "^2.1.2",
@@ -3524,10 +3518,9 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.10.0",
-      "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
-      "deprecated": "Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future",
       "dev": true,
       "inBundle": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
@@ -3547,9 +3540,9 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "integrity": "sha512-+5XZFpQZEY0cg5JaxLwGxDlKNKYxuXwGt8/Oi3UXm5/4ymrJve9d2CURituxv3rSrVCGZj4m1U1JlHTdcKt2Ng==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "abbrev": "1",
@@ -3561,16 +3554,16 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.0.3",
-      "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.1.10",
-      "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
@@ -3579,10 +3572,9 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "deprecated": "This package is no longer supported.",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
@@ -3593,9 +3585,9 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3603,9 +3595,9 @@
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3613,9 +3605,9 @@
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "wrappy": "1"
@@ -3623,9 +3615,9 @@
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3633,9 +3625,9 @@
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3643,10 +3635,9 @@
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "deprecated": "This package is no longer supported.",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
@@ -3655,9 +3646,9 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3665,16 +3656,16 @@
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.0",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.7",
-      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
       "dev": true,
       "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "optional": true,
       "dependencies": {
         "deep-extend": "^0.5.1",
@@ -3688,16 +3679,16 @@
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "integrity": "sha512-7Wl+Jz+IGWuSdgsQEJ4JunV0si/iMhg42MnQQG6h1R6TNeVenp4U9x5CC5v/gYqz/fENLQITAWXidNtVL0NNbw==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -3711,10 +3702,9 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.6.2",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "glob": "^7.0.5"
@@ -3725,30 +3715,30 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.1",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.5.0",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "bin": {
         "semver": "bin/semver"
@@ -3756,23 +3746,23 @@
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "integrity": "sha512-meQNNykwecVxdu1RlYMKpQx4+wefIYpmxi6gexo/KAbwquJrBUrBmKYJrE8KFkVQAAVWEnwNdu21PgrD77J3xA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -3780,9 +3770,9 @@
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -3795,9 +3785,9 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -3808,9 +3798,9 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3818,9 +3808,9 @@
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.1",
-      "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "chownr": "^1.0.1",
@@ -3837,16 +3827,16 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "inBundle": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.2",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "string-width": "^1.0.2"
@@ -3854,16 +3844,16 @@
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.0.2",
-      "integrity": "sha512-U+iKQ8rDYMRmvEpvDUIWZ3CtM9/imlAc+c1yJ7YV0vu+HNtP82sAkXzuDXPLkIPoLZohnXFSs9wf2E17xk5yZA==",
       "dev": true,
       "inBundle": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/function-bind": {

--- a/test/unit/component/stringify.js
+++ b/test/unit/component/stringify.js
@@ -38,14 +38,13 @@ describe('svg-react-loader/lib/component/stringify', () => {
                         should.
                         equal(
                             'var React = require(\'react\');\n\n' +
-                            'function SvgReactComponent (props) {\n' +
-                            '    return React.createElement("svg",props,' +
+                            'function SvgReactComponent ({version = "1.1", x = "0px", y = "0px", viewBox = "0 0 16 16", enableBackground = "new 0 0 16 16", xmlSpace = "preserve", className = "simple", ...restProps}) {\n' +
+                            '    return React.createElement("svg",Object.assign({version: version, x: x, y: y, viewBox: viewBox, enableBackground: enableBackground, xmlSpace: xmlSpace, className: className}, restProps),' +
                             '[React.createElement("rect",{"x":"0","y":"0",' +
                             '"width":"16","height":"16","fill":"#fff","key":0}),' +
                             'React.createElement("text",{"key":1},"Foobar")' +
                             ']);\n' +
                             '}\n\n' +
-                            'SvgReactComponent.defaultProps = ' + JSON.stringify(expectedProps) + ';\n\n' +
                             'module.exports = SvgReactComponent;\n\n' +
                             'SvgReactComponent.default = SvgReactComponent;\n'
                         );


### PR DESCRIPTION
## 🚀 React 19 Compatibility: Remove Deprecated `defaultProps`

### Problem

The current svg-react-loader generates React components using `defaultProps`, which is deprecated in React 18.3+ and removed in React 19. This results in:

- ⚠️ Console warnings in React 18.3+
- 💥 Broken functionality in React 19
- 🚫 Upgrade blockers for newer React versions

### Solution

This update replaces the deprecated `defaultProps` with modern default parameter destructuring, ensuring full compatibility with React 19 while preserving existing functionality.

### Key Changes

- Removed `defaultProps` generation in `lib/component/stringify.js`
- Updated prop handling in `lib/component/from-object.js`
- Refreshed related unit tests in `test/unit/component/stringify.js`

#### Example

**Before (Deprecated):**
```js
function IconComponent(props) {
  return React.createElement("svg", props, [...]);
}
IconComponent.defaultProps = { viewBox: "0 0 16 16", className: "icon" };
```

**After (Modern):**
```js
function IconComponent({ viewBox = "0 0 16 16", className = "icon", ...restProps }) {
  return React.createElement("svg", { viewBox, className, ...restProps }, [...]);
}
```

### Benefits

- 🟢 Enables safe upgrade to React 19
- 🔇 Eliminates console warnings in React 18.3+
- 🔄 Maintains existing API and behavior—zero breaking changes
- ⚡ Future-proofs code with recommended React patterns

### Testing

- All unit and integration tests pass
- Webpack builds (717 SVG modules) succeed
- Generated components render correctly in React

### Why This Matters

Projects relying on this loader can now confidently upgrade to React 19, avoiding breakages and deprecated patterns.

---

🔗 Related: PITCH-5590 (React 18.3.1 console warnings)  
📚 [React 19 Upgrade Guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis)